### PR TITLE
Fix/Unify Calculation Processor Reaction Chamber recipe

### DIFF
--- a/kubejs/server_scripts/ae2/reaction_chamber_add.js
+++ b/kubejs/server_scripts/ae2/reaction_chamber_add.js
@@ -128,7 +128,7 @@ ServerEvents.recipes((event) => {
         },
         input_items: [
           {
-            amount: 18,
+            amount: 9,
             ingredient: {
               item: item1,
             },
@@ -140,9 +140,9 @@ ServerEvents.recipes((event) => {
             },
           },
           {
-            amount: 36,
+            amount: 4,
             ingredient: {
-              item: 'minecraft:redstone',
+              item: 'minecraft:redstone_block',
             },
           },
         ],


### PR DESCRIPTION
0.45.1 has it require double the amount of `ae2:quartz` blocks that it should, 18 instead of 9. This fixes that, and also changes the redstone requirement back to 4 `minecraft:redstone_block` to put it in line with the Logic and Engineering Processor recipes

### Faulty Calculation Processor Recipe
<img width="723" height="929" alt="image" src="https://github.com/user-attachments/assets/66fb3257-3e22-495b-b07f-908963315db0" />

### Proper Logic Processor Recipe for comparison
<img width="725" height="928" alt="image" src="https://github.com/user-attachments/assets/5ee8e813-158f-4e2f-9cef-6ad0241dabb8" />
