### PR TITLE
[KubeJS][Loot] Give Azure Silver Ore proper silktouch behavior

### DIFF
--- a/kubejs/server_scripts/lootjs/lootjs_add.js
+++ b/kubejs/server_scripts/lootjs/lootjs_add.js
@@ -133,7 +133,7 @@ LootJS.modifiers((event) => {
     .when((c) =>
       c.matchMainHand(ItemFilter.hasEnchantment('minecraft:fortune'))
     );
-  const handleSilkTouch = LootEntry.of("kubejs:azure_silver_ore").when((c) =>
+  const applyWhenSilkTouch = LootEntry.of("kubejs:azure_silver_ore").when((c) =>
     c.matchMainHand(ItemFilter.hasEnchantment("minecraft:silk_touch"))
   );
   // Currently lacks a raw ore
@@ -142,7 +142,7 @@ LootJS.modifiers((event) => {
   event
     .addBlockLootModifier('kubejs:azure_silver_ore')
     .removeLoot(Ingredient.all)
-    .addAlternativesLoot(stickWhenFortune, handleSilkTouch ,metal);
+    .addAlternativesLoot(stickWhenFortune, applyWhenSilkTouch ,metal);
 });
 
 //'allthemodium:allthemodium_upgrade_smithing_template'


### PR DESCRIPTION
Azur silver ore drops its current item, even when silktouched.

I'd like to expand this with a proper raw ore addition so it matches current vanilla behavior, but in the meantime this just adds a silktouch entry for the ore block