### PR TITLE
[KubeJS][Recipes] Add bulk reaction chamber processor recipes for remaining processors

### DIFF
--- a/kubejs/server_scripts/ae2/reaction_chamber_add.js
+++ b/kubejs/server_scripts/ae2/reaction_chamber_add.js
@@ -157,8 +157,9 @@ ServerEvents.recipes((event) => {
 
   reaction_chamber1(event, 'minecraft:gold_block', 'ae2:logic_processor');
   reaction_chamber3(event, 'ae2:quartz_block', 'ae2:calculation_processor');
-  reaction_chamber1(event, 'ae2omnicells:ender_ingot_block', "ae2omnicells:omni_link_processor")
-  reaction_chamber1(event, 'ae2omnicells:netherite_scrap_block', "ae2omnicells:complex_link_processor")
+  reaction_chamber1(event, 'ae2omnicells:ender_ingot_block', "ae2omnicells:omni_link_processor");
+  reaction_chamber1(event, 'ae2omnicells:netherite_scrap_block', "ae2omnicells:complex_link_processor");
+  reaction_chamber1(event, 'advanced_ae:quantum_alloy_block', "advanced_ae:quantum_processor");
   reaction_chamber1(
     event,
     'minecraft:diamond_block',


### PR DESCRIPTION
Added compressed reaction chamber recipes for the remaining 3 processor types
All of these recipes already have Circuit Slicer recipes, so these just compress steps, a-la the other ones
<img width="780" height="558" alt="image" src="https://github.com/user-attachments/assets/6172ead1-7091-4d9c-aa16-7e089cc4e8af" />
<img width="621" height="367" alt="image" src="https://github.com/user-attachments/assets/046a529a-2ea0-4b16-a349-93445bb7a585" />
<img width="643" height="387" alt="image" src="https://github.com/user-attachments/assets/8b57710c-5194-4d74-b9af-13402c740739" />
