### PR TITLE
some small changes

### DIFF
--- a/config/botania-common.toml
+++ b/config/botania-common.toml
@@ -5,7 +5,7 @@ flowerBindingForceCheck = true
 #Set to false to disable the ability for the Hand of Ender to pickpocket other players' ender chests
 enderPickpocket = true
 #Set this to false to disable the Mana Enchanter. Since some people find it OP or something. This only disables the entry and creation. Old ones that are already in the world will stay.
-manaEnchanter = true
+manaEnchanter = false
 #Set this to false to disable the Relic System. This only disables the entries, drops and achievements. Old ones that are already in the world will stay.
 relics = true
 #Set this to true to invert the Ring of Magnetization's controls (from shift to stop to shift to work)

--- a/config/industrialforegoing/machine-misc.toml
+++ b/config/industrialforegoing/machine-misc.toml
@@ -39,7 +39,7 @@
 		#Max Essence [mb] - Default: [64000 mb]
 		tankSize = 64000
 		#Ignore max level for enchanting
-		ignoreEnchantMaxLevels = true
+		ignoreEnchantMaxLevels = false
 
 	[MachineMiscConfig.EnchantmentFactoryConfig]
 		#Cooldown Time in Ticks [20 Ticks per Second] - Default: [50 (2.5s)]

--- a/kubejs/server_scripts/mods_recipes/masterfull_machinery/adv_awakening_altar/adv_awakening_altar_recipe.js
+++ b/kubejs/server_scripts/mods_recipes/masterfull_machinery/adv_awakening_altar/adv_awakening_altar_recipe.js
@@ -1014,7 +1014,7 @@ MMEvents.createProcesses((event) => {
       type: 'mm:input/consume',
       ingredient: {
         type: 'mm:energy',
-        amount: 200000000,
+        amount: 800000000,
       },
     })
     .output({

--- a/kubejs/server_scripts/mods_recipes/masterfull_machinery/auto_sieve/recipes/infinity_ingot_11.js
+++ b/kubejs/server_scripts/mods_recipes/masterfull_machinery/auto_sieve/recipes/infinity_ingot_11.js
@@ -16,7 +16,7 @@ MMEvents.createProcesses((event) => {
       type: 'mm:input/consume',
       ingredient: {
         type: 'mm:energy',
-        amount: 100000,
+        amount: 300000,
       },
     })
     .output({

--- a/kubejs/server_scripts/mods_recipes/masterfull_machinery/fire_attuned/fire_attuned_recipes_2.js
+++ b/kubejs/server_scripts/mods_recipes/masterfull_machinery/fire_attuned/fire_attuned_recipes_2.js
@@ -17,7 +17,7 @@ MMEvents.createProcesses((event) => {
       type: 'mm:input/consume',
       ingredient: {
         type: 'mm:energy',
-        amount: 16384,
+        amount: 163840,
       },
     })
     .input({
@@ -54,7 +54,7 @@ MMEvents.createProcesses((event) => {
       type: 'mm:input/consume',
       ingredient: {
         type: 'mm:energy',
-        amount: 16384,
+        amount: 163840,
       },
     })
     .input({
@@ -212,7 +212,7 @@ MMEvents.createProcesses((event) => {
       type: 'mm:input/consume',
       ingredient: {
         type: 'mm:energy',
-        amount: 100000000,
+        amount: 10000000,
       },
     })
     .output({
@@ -295,7 +295,7 @@ MMEvents.createProcesses((event) => {
       type: 'mm:input/consume',
       ingredient: {
         type: 'mm:energy',
-        amount: 5120000,
+        amount: 1280000,
       },
     })
     .output({
@@ -303,7 +303,7 @@ MMEvents.createProcesses((event) => {
       ingredient: {
         type: 'mm:fluid',
         fluid: 'advanced_ae:quantum_infusion_source',
-        amount: 16000,
+        amount: 64000,
       },
     });
 });

--- a/kubejs/server_scripts/mods_recipes/masterfull_machinery/pinky/pinky_recipes.js
+++ b/kubejs/server_scripts/mods_recipes/masterfull_machinery/pinky/pinky_recipes.js
@@ -146,7 +146,7 @@ MMEvents.createProcesses((event) => {
       ingredient: {
         type: 'mm:item',
         item: 'minecraft:iron_ingot',
-        count: 256,
+        count: 128,
       },
     })
     .input({
@@ -154,7 +154,7 @@ MMEvents.createProcesses((event) => {
       ingredient: {
         type: 'mm:item',
         item: 'minecraft:redstone',
-        count: 256,
+        count: 64,
       },
     })
     .input({

--- a/kubejs/server_scripts/mods_recipes/mysticalagriculture/add_seeds_crafts.js
+++ b/kubejs/server_scripts/mods_recipes/mysticalagriculture/add_seeds_crafts.js
@@ -173,7 +173,7 @@ ServerEvents.recipes((event) => {
   ]);
 
   seedtiercrafting2(event, 'mysticalagriculture:basalt_seeds', [
-    '#forge:stone/basalt',
+    'minecraft:basalt',
   ]);
 
   seedtiercrafting2(event, 'mysticalagriculture:marble_seeds', [

--- a/kubejs/server_scripts/mods_recipes/projecte/add.js
+++ b/kubejs/server_scripts/mods_recipes/projecte/add.js
@@ -1,16 +1,4 @@
 ServerEvents.recipes((event) => {
-  create3x3(event, Item.of('projecte:medium_covalence_dust', 40), [
-    'minecraft:air',
-    'minecraft:air',
-    'minecraft:air',
-    'minecraft:redstone',
-    'minecraft:air',
-    'minecraft:iron_ingot',
-    'minecraft:air',
-    'minecraft:air',
-    'minecraft:air',
-  ]);
-
   create3x3(event, 'projecte:gem_helmet', [
     'projecte:rm_helmet',
     'projecte:klein_star_omega',

--- a/kubejs/server_scripts/recipe_change/remove_recipes.js
+++ b/kubejs/server_scripts/recipe_change/remove_recipes.js
@@ -298,7 +298,6 @@ const removeItemsbyID = [
   'jei:/allthemodium/mek_processing/allthemodium/ore/deepslate_from_raw',
   'jei:/allthemodium/mek_processing/vibranium/ore/from_dust',
   'extendedcrafting:redstone_ingot',
-  'projecte:medium_covalence_dust',
   'ironfurnaces:rainbow_plating',
   'ironfurnaces:rainbow_core',
   'emi:/crafting/repairing/mysticalagriculture/infusion_crystal',

--- a/kubejs/server_scripts/recipe_change/replace_items.js
+++ b/kubejs/server_scripts/recipe_change/replace_items.js
@@ -314,6 +314,11 @@ ServerEvents.recipes((event) => {
   );
   event.replaceInput(
     { output: 'logisticsnetworks:netherite_upgrade' },
+    'minecraft:smooth_stone',
+    'logisticsnetworks:diamond_upgrade'
+  );
+  event.replaceInput(
+    { output: 'logisticsnetworks:netherite_upgrade' },
     'minecraft:chest',
     'allthemodium:allthemodium_ingot'
   );

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -102,7 +102,7 @@ ServerEvents.tags('fluid', (event) => {
 
 //add Tags to Blocks
 ServerEvents.tags('block', event => {
-  event.add('ae2:growth_acceleratable', [
+  event.add('mysticalagriculture:crops', [
     'mysticalagriculture:boron_crop',
     'mysticalagriculture:cognizant_dust_crop',
     'mysticalagriculture:dark_metal_ingot_crop',


### PR DESCRIPTION
disabled mana enchanter and set ignoreEnchantMaxLevels to false for enchantment applicator, this prevent from enchantments going above their limit.

removed medium covalence dust recipe as its redundant (projecte adds the same recipe but shapeless)

fixed some mm muliblock recipes to take proper amount of energy/items (for example crimson ingot was requiring x32 and x64 iron/redstone respectively instead of x16 compared to tier 1 recipe)

changed basalt seed from requiring enviromats basalt to vanilla

changed netherite upgrade from logistics networks to require diamond upgrade

changed mystical agriculture seed block tags from ae2:growth_acceleratable to mysticalagriculture:crops so they get the same tags as other ma seeds