### PR TITLE
Some last minute changes

### DIFF
--- a/config/jei/blacklist.cfg
+++ b/config/jei/blacklist.cfg
@@ -679,7 +679,6 @@ mekanism:creative_fluid_tank{mekData:{FluidTanks:[{Tank:0b,stored:{Amount:214748
 rftoolsutility:syringe{mobId:"bygonenether:piglin_hunter"}
 tconstruct:sledge_hammer{Damage:0,tic_broken:0b,tic_materials:["tconstruct:iron","tconstruct:iron","tconstruct:iron","tconstruct:iron"],tic_modifiers:[{level:4,name:"tconstruct:magnetic"},{level:2,name:"tconstruct:smite"}],tic_multipliers:{"tconstruct:attack_damage":1.35f,"tconstruct:durability":4.0f,"tconstruct:mining_speed":0.4f},tic_persistent:{},tic_stats:{"tconstruct:attack_damage":6.75f,"tconstruct:attack_speed":0.75f,"tconstruct:durability":1100.0f,"tconstruct:harvest_tier":"minecraft:iron","tconstruct:mining_speed":2.4f},tic_volatile_data:{abilities:1,upgrades:2}}
 cataclysm:ignis_spawn_egg
-tconstruct:tinkers_gadgetry
 tconstruct:sledge_hammer{Damage:0,tic_broken:0b,tic_materials:["tcintegrations:manasteel","tcintegrations:manasteel","tcintegrations:manasteel","tcintegrations:manasteel"],tic_modifiers:[{level:4,name:"tconstruct:ductile"},{level:4,name:"tcintegrations:mana"},{level:2,name:"tconstruct:smite"}],tic_multipliers:{"tconstruct:attack_damage":1.35f,"tconstruct:durability":4.0f,"tconstruct:mining_speed":0.4f},tic_persistent:{},tic_stats:{"tconstruct:armor_toughness":4.0f,"tconstruct:attack_damage":10.8675f,"tconstruct:attack_speed":0.78749996f,"tconstruct:durability":4556.9995f,"tconstruct:harvest_tier":"minecraft:diamond","tconstruct:mining_speed":2.52f,"tconstruct:projectile_damage":2.4f},tic_volatile_data:{abilities:1,upgrades:2}}
 tconstruct:broad_axe_head{Material:"tcompat:draconic"}
 nuclearcraft:platinum_slurry_bucket
@@ -3341,7 +3340,6 @@ tconstruct:travelers_boots{Damage:0,tic_broken:0b,tic_materials:["mysticalagradd
 rftoolsutility:syringe{mobId:"cataclysm:hippocamtus"}
 enderio:clear_glass_a_yellow
 mekanism:creative_fluid_tank:mekanism:uranium_oxide:
-tconstruct:materials_and_you
 cataclysm:the_baby_leviathan_spawn_egg
 tconstruct:broad_axe_head{Material:"tconstruct:wood"}
 mekanism:creative_fluid_tank:integrateddynamics:menril_resin:
@@ -3844,7 +3842,6 @@ enviromats:brown_alabaster_cobble_stairs
 tconstruct:longbow{Damage:0,tic_broken:0b}
 tconstruct:longbow{Damage:0,tic_broken:0b,tic_materials:["tcintegrations:livingrock","tcintegrations:livingrock","tcintegrations:livingrock","tconstruct:slimeskin"],tic_modifiers:[{level:1,name:"tconstruct:overslime"},{level:3,name:"tconstruct:stonebound"},{level:1,name:"tconstruct:overgrowth"}],tic_multipliers:{"tconstruct:durability":1.5f},tic_persistent:{},tic_stats:{"tconstruct:accuracy":0.5f,"tconstruct:attack_damage":0.75f,"tconstruct:draw_speed":1.1f,"tconstruct:durability":598.49994f,"tconstruct:overslime":75.0f,"tconstruct:velocity":1.1f},tic_volatile_data:{abilities:1,upgrades:2}}
 mekanism:creative_fluid_tank:nuclearcraft:depleted_fuel_californium_lecf_249_za:
-tconstruct:mighty_smelting
 enderio:fused_quartz_p_white
 tconstruct:excavator{Damage:0,tic_broken:0b,tic_materials:["tconstruct:rose_gold","tconstruct:rose_gold","tconstruct:rose_gold","tconstruct:rose_gold"],tic_modifiers:[{level:2,name:"tconstruct:knockback"},{level:1,name:"tconstruct:pathing"},{level:4,name:"tconstruct:enhanced"}],tic_multipliers:{"tconstruct:attack_damage":1.2f,"tconstruct:durability":3.75f,"tconstruct:mining_speed":0.3f},tic_persistent:{},tic_stats:{"tconstruct:attack_damage":3.0f,"tconstruct:attack_speed":1.1f,"tconstruct:durability":459.375f,"tconstruct:harvest_tier":"minecraft:gold","tconstruct:mining_speed":2.9700003f},tic_volatile_data:{abilities:1,upgrades:6}}
 bloodmagic:upgradetome{livingStats:{maxPoints:0,upgrades:[{exp:800.0d,key:"bloodmagic:physical_protect"}]}}
@@ -4319,7 +4316,6 @@ tconstruct:adze_head{Material:"tconstruct:bone"}
 twilightforest:death_tome_spawner
 bloodmagic:upgradetome{livingStats:{maxPoints:0,upgrades:[{exp:60.0d,key:"bloodmagic:dig_slowdown"}]}}
 tconstruct:mattock{Damage:0,tic_broken:0b,tic_materials:["tconstruct:wood","tconstruct:wood","tconstruct:wood"],tic_modifiers:[{level:3,name:"tconstruct:cultivated"},{level:1,name:"tconstruct:tilling"}],tic_multipliers:{"tconstruct:attack_damage":1.1f,"tconstruct:durability":1.25f,"tconstruct:mining_speed":1.1f},tic_persistent:{},tic_stats:{"tconstruct:attack_damage":1.6500001f,"tconstruct:attack_speed":0.9f,"tconstruct:durability":75.0f,"tconstruct:mining_speed":2.2f},tic_volatile_data:{abilities:1,upgrades:3}}
-tconstruct:fantastic_foundry
 nuclearcraft:depleted_fuel_thorium_tbu_ni_bucket
 sophisticatedstorage:limited_iron_barrel_4:{mainColor:10329495,accentColor:10329495,flatTop:false}
 botanypotstiers:creative_pink_glazed_terracotta_hopper_botany_pot
@@ -6710,6 +6706,7 @@ nuclearcraft:cobalt_60_bucket
 enderio:filled_soul_vial{BlockEntityTag:{EntityStorage:{Entity:{id:"minecraft:cod"}}}}
 mekanism:creative_chemical_tank{mekData:{SlurryTanks:[{Tank:0b,stored:{amount:9223372036854775807L,slurryName:"alltheores:dirty_nickel"}}]}}
 enderio:broken_spawner{BlockEntityTag:{EntityStorage:{Entity:{id:"cataclysm:ancient_remnant"}}}}
+avaritia_expand:blaze_furnace
 minecraft:suspicious_stew{Effects:[{EffectDuration:6000,EffectId:96,"forge:effect_id":"botania:soul_cross"}]}
 endlessbiomes:bottle_of_void
 mekanism:creative_fluid_tank{mekData:{FluidTanks:[{Tank:0b,stored:{Amount:2147483647,FluidName:"enderio:cloud_seed_concentrated"}}]}}
@@ -8446,6 +8443,7 @@ tconstruct:vein_hammer{Damage:0,tic_broken:0b,tic_materials:["mysticalagradditio
 tconstruct:travelers_boots
 mekanism:creative_fluid_tank:mekanism_extras:rich_naquadah_fuel:
 enderio:clear_glass_nm_white
+woot_revived:creative_tank
 mekanism:creative_fluid_tank{mekData:{FluidTanks:[{Tank:0b,stored:{Amount:2147483647,FluidName:"enderio:hootch"}}]}}
 mekanism:creative_fluid_tank:enderio:cloud_seed:
 enderio:clear_glass_dna_light_gray
@@ -9926,7 +9924,6 @@ mekanism:creative_fluid_tank:nuclearcraft:curium_245_ox:
 sophisticatedstorage:copper_chest:{mainColor:16701501,accentColor:16701501,doubleChest:false}
 fluid:nuclearcraft:fuel_mixed_mix_239_ni
 tconstruct:sword{Damage:0,tic_broken:0b,tic_materials:["mysticalagradditions:imperium","mysticalagradditions:imperium","mysticalagradditions:imperium"],tic_modifiers:[{level:3,name:"mysticalagradditions:prosperous"},{level:1,name:"tconstruct:silky_shears"}],tic_multipliers:{"tconstruct:durability":1.1f,"tconstruct:mining_speed":0.5f},tic_persistent:{},tic_stats:{"tconstruct:attack_damage":21.199001f,"tconstruct:attack_speed":1.7600001f,"tconstruct:durability":3795.0f,"tconstruct:harvest_tier":"minecraft:netherite","tconstruct:mining_speed":10.33125f},tic_volatile_data:{abilities:1,upgrades:3}}
-tconstruct:puny_smelting
 sophisticatedstorage:limited_netherite_barrel_1:{mainColor:13061821,accentColor:13061821,flatTop:false}
 tconstruct:pickadze{Damage:0,tic_broken:0b,tic_materials:["tconstruct:lead","tconstruct:lead","tconstruct:lead"],tic_modifiers:[{level:3,name:"tconstruct:heavy"},{level:1,name:"tconstruct:pathing"}],tic_multipliers:{"tconstruct:attack_damage":1.15f,"tconstruct:durability":1.3f,"tconstruct:mining_speed":0.75f},tic_persistent:{},tic_stats:{"tconstruct:attack_damage":5.752875f,"tconstruct:attack_speed":1.2349999f,"tconstruct:durability":233.99998f,"tconstruct:harvest_tier":"minecraft:iron","tconstruct:knockback_resistance":0.45000002f,"tconstruct:mining_speed":3.75f,"tconstruct:projectile_damage":2.6f},tic_volatile_data:{abilities:1,upgrades:3}}
 born_in_chaos_v1:lord_pumpkinhead_icon
@@ -10027,6 +10024,7 @@ mekanism:creative_fluid_tank{mekData:{FluidTanks:[{Tank:0b,stored:{Amount:214748
 mekanism:creative_fluid_tank{mekData:{FluidTanks:[{Tank:0b,stored:{Amount:2147483647,FluidName:"thermal_extra:raw_zinc"}}]}}
 sophisticatedstorage:copper_shulker_box:{mainColor:15961002,accentColor:15961002}
 mekanism:creative_fluid_tank{mekData:{FluidTanks:[{Tank:0b,stored:{Amount:2147483647,FluidName:"thermal_processing:molten_rose_gold"}}]}}
+pneumaticcraft:thaumcraft_upgrade
 mekanism:creative_fluid_tank:nuclearcraft:helium:
 mysticalagriculture:awakened_supremium_staff
 minecraft:splash_potion{Potion:"cyclic:reach_distance"}
@@ -12306,7 +12304,6 @@ enderio:broken_spawner{BlockEntityTag:{EntityStorage:{Entity:{id:"minecraft:cow"
 bloodmagic:upgradetome{livingStats:{maxPoints:0,upgrades:[{exp:200.0d,key:"bloodmagic:jump"}]}}
 exdeorum:jacaranda_compressed_sieve
 bloodmagic:upgradetome{livingStats:{maxPoints:0,upgrades:[{exp:150000.0d,key:"bloodmagic:digging"}]}}
-tconstruct:encyclopedia
 nuclearcraft:helium_3_bucket
 tconstruct:dagger{Damage:0,tic_broken:0b,tic_materials:["allthemodium:unobtainium","allthemodium:unobtainium"],tic_modifiers:[{level:10,name:"tconstruct:lightweight"},{level:6,name:"tconstruct:insatiable"},{level:1,name:"tconstruct:offhand_attack"},{level:12,name:"tconstruct:momentum"},{level:1,name:"tconstruct:padded"},{level:1,name:"tconstruct:silky_shears"}],tic_multipliers:{"tconstruct:attack_damage":0.65f,"tconstruct:durability":0.75f,"tconstruct:mining_speed":0.75f},tic_persistent:{},tic_stats:{"tconstruct:attack_damage":187.2f,"tconstruct:attack_speed":78.200005f,"tconstruct:block_amount":10.0f,"tconstruct:draw_speed":1.3f,"tconstruct:durability":39187.5f,"tconstruct:harvest_tier":"allthemodium:unobtainium","tconstruct:mining_speed":645.15f,"tconstruct:use_item_speed":1.0f,"tconstruct:velocity":1.3f},tic_volatile_data:{abilities:1,"tconstruct:duel_wielding":1b,upgrades:3}}
 silentgems:chiseled_topaz

--- a/kubejs/server_scripts/mods_recipes/masterfull_machinery/essenceforge/essenceforge_layout.js
+++ b/kubejs/server_scripts/mods_recipes/masterfull_machinery/essenceforge/essenceforge_layout.js
@@ -144,8 +144,7 @@ MMEvents.createStructures((event) => {
           block: 'chisel_chipped_integration:factory_blue_framed_circuit',
         })
         .key('I', {
-          portType: 'mm:energy',
-          input: true,
+          block: 'mm:gigantic_energy_port_input',
         })
         .key('L', {
           block: 'botanicalextramachinery:crimson_ingot_block',
@@ -215,8 +214,7 @@ MMEvents.createStructures((event) => {
           block: 'chisel_chipped_integration:factory_blue_framed_circuit',
         })
         .key('I', {
-          portType: 'mm:energy',
-          input: true,
+          block: 'mm:gigantic_energy_port_input',
         })
         .key('L', {
           block: 'botanicalextramachinery:crimson_ingot_block',

--- a/kubejs/server_scripts/recipe_change/remove_recipes.js
+++ b/kubejs/server_scripts/recipe_change/remove_recipes.js
@@ -209,6 +209,8 @@ const removeItemsbyOutput = [
   'packagedexcrafting:basic_crafter',
   'cyclic:glass_connected',
   'industrialforegoing:hydroponic_simulation_processor',
+  'avaritia_expand:neutron_decompose',
+  'avaritia_expand:blaze_furnace',
 ];
 
 const removeItemsbyID = [


### PR DESCRIPTION
Essenceforge T3 and T4 use specific Energy port because the recipes need them

Blacklist some items
unblacklist Tinker's Construct books

remove recipes of hidden items