### PR TITLE
Lower Alloyer Singularity prices

### DIFF
--- a/config/extendedcrafting/singularities/abyssal_ingot.json
+++ b/config/extendedcrafting/singularities/abyssal_ingot.json
@@ -7,5 +7,5 @@
   "ingredient": {
     "item": "thermal_extra:abyssal_ingot"
   },
-  "materialCount": 10000
+  "materialCount": 1500
 }

--- a/config/extendedcrafting/singularities/dragonsteel_ingot.json
+++ b/config/extendedcrafting/singularities/dragonsteel_ingot.json
@@ -7,5 +7,5 @@
   "ingredient": {
     "item": "thermal_extra:dragonsteel_ingot"
   },
-  "materialCount": 10000
+  "materialCount": 1500
 }

--- a/config/extendedcrafting/singularities/end_steel_ingot.json
+++ b/config/extendedcrafting/singularities/end_steel_ingot.json
@@ -7,5 +7,5 @@
   "ingredient": {
     "item": "enderio:end_steel_ingot"
   },
-  "materialCount": 10000
+  "materialCount": 1500
 }

--- a/config/extendedcrafting/singularities/enderium_ingot.json
+++ b/config/extendedcrafting/singularities/enderium_ingot.json
@@ -7,5 +7,5 @@
   "ingredient": {
     "item": "thermal:enderium_ingot"
   },
-  "materialCount": 10000
+  "materialCount": 3000
 }

--- a/config/extendedcrafting/singularities/lumium_ingot.json
+++ b/config/extendedcrafting/singularities/lumium_ingot.json
@@ -7,5 +7,5 @@
   "ingredient": {
     "item": "thermal:lumium_ingot"
   },
-  "materialCount": 10000
+  "materialCount": 6000
 }

--- a/config/extendedcrafting/singularities/prismalium_ingot.json
+++ b/config/extendedcrafting/singularities/prismalium_ingot.json
@@ -7,5 +7,5 @@
   "ingredient": {
     "item": "thermalendergy:prismalium_ingot"
   },
-  "materialCount": 10000
+  "materialCount": 3000
 }

--- a/config/extendedcrafting/singularities/shellite_ingot.json
+++ b/config/extendedcrafting/singularities/shellite_ingot.json
@@ -7,5 +7,5 @@
   "ingredient": {
     "item": "thermal_extra:shellite_ingot"
   },
-  "materialCount": 2500
+  "materialCount": 1500
 }

--- a/config/extendedcrafting/singularities/signalum_ingot.json
+++ b/config/extendedcrafting/singularities/signalum_ingot.json
@@ -7,5 +7,5 @@
   "ingredient": {
     "item": "thermal:signalum_ingot"
   },
-  "materialCount": 10000
+  "materialCount": 6000
 }

--- a/config/extendedcrafting/singularities/soul_infused_ingot.json
+++ b/config/extendedcrafting/singularities/soul_infused_ingot.json
@@ -7,5 +7,5 @@
   "ingredient": {
     "item": "thermal_extra:soul_infused_ingot"
   },
-  "materialCount": 10000
+  "materialCount": 1500
 }

--- a/config/extendedcrafting/singularities/twinite_ingot.json
+++ b/config/extendedcrafting/singularities/twinite_ingot.json
@@ -7,5 +7,5 @@
   "ingredient": {
     "item": "thermal_extra:twinite_ingot"
   },
-  "materialCount": 10000
+  "materialCount": 1500
 }

--- a/config/jei/blacklist.cfg
+++ b/config/jei/blacklist.cfg
@@ -13205,3 +13205,4 @@ enderio:clear_glass_dnp
 enderio:broken_spawner{BlockEntityTag:{EntityStorage:{Entity:{id:"twilightforest:giant_miner"}}}}
 mekanism:creative_chemical_tank:moremekanismprocessing:clean_cobalt::
 enderio:clear_glass_np_white
+cyclic:crusher

--- a/kubejs/client_scripts/jei/hide_enviromats.js
+++ b/kubejs/client_scripts/jei/hide_enviromats.js
@@ -1,0 +1,18 @@
+JEIEvents.hideItems((event) => {
+  let config = JsonIO.read('kubejs/config/jei_config.json')
+  if (config.enviromats == false) {
+    return;
+  }
+
+  let hideRegex = /^enviromats:.*(cobble|polished|brick|tile).*$/;
+  
+  let enviromatsItems = Ingredient.of('@enviromats').getItemIds();
+  
+  enviromatsItems.forEach(itemId => {
+    let matchesPattern = hideRegex.test(itemId);
+    
+    if (matchesPattern) {
+      event.hide(itemId);
+    }
+  });
+});

--- a/kubejs/config/jei_config.json
+++ b/kubejs/config/jei_config.json
@@ -9,5 +9,6 @@
   "rechiseled": true,
   "chisel_chipped_integration": true,
   "spawn_eggs": true,
-  "compressium": true
+  "compressium": true,
+  "enviromats": true
 }

--- a/kubejs/server_scripts/mods_recipes/cyclic/add.js
+++ b/kubejs/server_scripts/mods_recipes/cyclic/add.js
@@ -85,18 +85,6 @@ ServerEvents.recipes((event) => {
     'thermal:copper_nugget',
   ]);
 
-  create3x3(event, 'cyclic:crusher', [
-    'compressium:cobblestone_1',
-    'thermal:copper_nugget',
-    'compressium:cobblestone_1',
-    'minecraft:stonecutter',
-    'cyclic:flint_block',
-    'minecraft:stonecutter',
-    'compressium:cobblestone_1',
-    'thermal:copper_nugget',
-    'compressium:cobblestone_1',
-  ]);
-
   create3x3(event, 'cyclic:dropper', [
     'thermal:copper_nugget',
     'compressium:cobblestone_1',

--- a/kubejs/server_scripts/mods_recipes/masterfull_machinery/multi_compressor/multi_compressor_recipes.js
+++ b/kubejs/server_scripts/mods_recipes/masterfull_machinery/multi_compressor/multi_compressor_recipes.js
@@ -3,7 +3,7 @@ MMEvents.createProcesses((event) => {
   const RECIPES = {
     abyssal_ingot: {
       inputItem: 'thermal_extra:abyssal_block',
-      count: 1112,
+      count: 167,
     },
     allthemodium_ingot: {
       inputItem: 'allthemodium:allthemodium_block',
@@ -59,7 +59,7 @@ MMEvents.createProcesses((event) => {
     },
     dragonsteel_ingot: {
       inputItem: 'thermal_extra:dragonsteel_block',
-      count: 834,
+      count: 167,
     },
     electrum: {
       inputItem: 'thermal:electrum_block',
@@ -70,14 +70,14 @@ MMEvents.createProcesses((event) => {
     },
     end_steel_ingot: {
       inputItem: 'enderio:end_steel_block',
-      count: 1112,
+      count: 167,
     },
     ender_ingot: {
       inputItem: 'extendedcrafting:ender_ingot_block',
     },
     enderium_ingot: {
       inputItem: 'thermal:enderium_block',
-      count: 1112,
+      count: 333,
     },
     enhanced_ender_ingot: {
       inputItem: 'extendedcrafting:enhanced_ender_ingot_block',
@@ -177,7 +177,7 @@ MMEvents.createProcesses((event) => {
     },
     lumium_ingot: {
       inputItem: 'thermal:lumium_block',
-      count: 1112,
+      count: 667,
     },
     manasteel_ingot: {
       inputItem: 'botania:manasteel_block',
@@ -217,7 +217,7 @@ MMEvents.createProcesses((event) => {
     },
     prismalium_ingot: {
       inputItem: 'thermalendergy:prismalium_block',
-      count: 1112,
+      count: 333,
     },
     prosperity_ingot: {
       inputItem: 'mysticalagriculture:prosperity_ingot_block',
@@ -241,11 +241,11 @@ MMEvents.createProcesses((event) => {
     },
     shellite_ingot: {
       inputItem: 'thermal_extra:shellite_block',
-      count: 278,
+      count: 167,
     },
     signalum_ingot: {
       inputItem: 'thermal:signalum_block',
-      count: 1112,
+      count: 667,
     },
     silver: {
       inputItem: 'thermal:silver_block',
@@ -255,7 +255,7 @@ MMEvents.createProcesses((event) => {
     },
     soul_infused_ingot: {
       inputItem: 'thermal_extra:soul_infused_block',
-      count: 1112,
+      count: 167,
     },
     soulium_ingot: {
       inputItem: 'mysticalagriculture:soulium_ingot_block',
@@ -285,7 +285,7 @@ MMEvents.createProcesses((event) => {
     },
     twinite_ingot: {
       inputItem: 'thermal_extra:twinite_block',
-      count: 1112,
+      count: 167,
     },
     unobtainium_allthemodium_alloy_ingot: {
       inputItem: 'allthemodium:unobtainium_allthemodium_alloy_ingot',
@@ -309,8 +309,11 @@ MMEvents.createProcesses((event) => {
   // 500 = 56
   // 1000 = 111
   // 1250 = 139
+  // 1500 = 167
   // 2500 = 278
+  // 3000 = 333
   // 5000 = 556
+  // 6000 = 667
   // 7500 = 834
   // 10000 = 1111
   // 12500 = 1389

--- a/kubejs/server_scripts/mods_recipes/mekanism/add.js
+++ b/kubejs/server_scripts/mods_recipes/mekanism/add.js
@@ -269,7 +269,7 @@ ServerEvents.recipes((event) => {
     1,
     'minecraft:diamond',
     1,
-    'nuclearcraft:graphite_ingot',
+    'bigreactors:graphite_ingot',
     'nuclearcraft:hard_carbon_ingot',
     1
   );

--- a/kubejs/server_scripts/recipe_change/remove_recipes.js
+++ b/kubejs/server_scripts/recipe_change/remove_recipes.js
@@ -536,7 +536,6 @@ const removeItemsbyID = [
   'alltheores:mek_processing/nickel/ore/from_dust',
   'mekanism:processing/diamond/to_ore',
   'botania:red_string_alt',
-  'minecraft:kjs/cyclic_crusher',
   'minecraft:gravel_from_compressed_gravel',
   'nuclearcraft:aluminum_block',
   '',


### PR DESCRIPTION
As discussed here https://discord.com/channels/1377546554638073927/1504932567009460367 with KYO297, having all Alloyer ingots Singularity at 10 000 takes way too long to craft

This reduces them to
1 500 for ingots that craft 1
3 000 for ingots that craft 2
6 000 for ingots that craft 4

Keep in mind this is just 10 of the 81 singularities needed, it's not gonna impact the price of it much as most those materials are free but it's gonna affect the time and the lag a lot