### PR TITLE
small changes

### DIFF
--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -356,5 +356,7 @@
 
   "tooltip.kubejs.wither_token": "Craft me using a Self Aware Data Model.",
   "tooltip.kubejs.wither_token_not_self_aware": "I wasn't crafted using a Self Aware Data Model, craft me back into a Data Model.",
-  "tooltip.kubejs.wither_token_self_aware": "I was crafted using a Self Aware Data Model"
+  "tooltip.kubejs.wither_token_self_aware": "I was crafted using a Self Aware Data Model",
+
+  "tooltip.mekanism.absolute_fluid_tank_nuclearcraft_polonium": "I contain Nuclearcraft Polonium" 
 }

--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -455,4 +455,14 @@ ItemEvents.tooltip((event) => {
       )
     }
   })
+
+  event.addAdvanced(['mekanism_extras:absolute_fluid_tank'], (item, advanced, text) => {
+    if (!item.nbt) return;
+
+    if (item.nbt.mekData.FluidTanks[0].stored.FluidName == 'nuclearcraft:polonium') {
+      text.add(
+        Text.translate('tooltip.mekanism.absolute_fluid_tank_nuclearcraft_polonium').red()
+      )
+    }
+  })
 });

--- a/kubejs/server_scripts/mods_recipes/extendedcrafting/endgame_items/creative_chemical_tank.js
+++ b/kubejs/server_scripts/mods_recipes/extendedcrafting/endgame_items/creative_chemical_tank.js
@@ -103,7 +103,7 @@ ServerEvents.recipes((event) => {
           type: 'forge:partial_nbt',
           item: 'mekanism_extras:absolute_chemical_tank',
           count: 1,
-          nbt: '{mekData:{GasTanks:[{Tank:0b,stored:{amount:65536000L,gasName:\"mekanism:oxygen\"}}]}}',
+          nbt: '{mekData:{GasTanks:[{Tank:0b,stored:{amount:131072000L,gasName:\"mekanism:oxygen\"}}]}}',
         },
         S: {
           type: 'forge:partial_nbt',
@@ -115,7 +115,7 @@ ServerEvents.recipes((event) => {
           type: 'forge:partial_nbt',
           item: 'mekanism_extras:absolute_chemical_tank',
           count: 1,
-          nbt: '{mekData:{GasTanks:[{Tank:0b,stored:{amount:65536000L,gasName:\"mekanism:hydrogen\"}}]}}',
+          nbt: '{mekData:{GasTanks:[{Tank:0b,stored:{amount:131072000L,gasName:\"mekanism:hydrogen\"}}]}}',
         },
         U: {
           type: 'forge:partial_nbt',

--- a/kubejs/server_scripts/recipe_change/replace_items.js
+++ b/kubejs/server_scripts/recipe_change/replace_items.js
@@ -35,6 +35,11 @@ ServerEvents.recipes((event) => {
     'draconicevolution:chaotic_capacitor',
     'kubejs:chaotic_capacitor'
   );
+  event.replaceOutput(
+    { output: 'draconicevolution:creative_capacitor' },
+    'draconicevolution:creative_capacitor',
+    'kubejs:creative_capacitor'
+  );
   event.replaceInput(
     { output: 'ender_dragon_loot:dragon_hoe' },
     'ender_dragon_loot:dragon_scale',


### PR DESCRIPTION
change creative_chemical_tank.js so the craft wants all tanks full

change draconicevolution:creative_capacitor craft to give kubejs:creative_capacitor instead

add tooltip to mekanism_extras:absolute_fluid_tank for nuclearcraft:polonium

