### PR TITLE
Make hellforged parts not ridiculous

### DIFF
--- a/kubejs/server_scripts/mods_recipes/masterfull_machinery/multi_compactor/multi_compactor_recipes.js
+++ b/kubejs/server_scripts/mods_recipes/masterfull_machinery/multi_compactor/multi_compactor_recipes.js
@@ -177,7 +177,7 @@ MMEvents.createProcesses((event) => {
       type: 'mm:input/consume',
       ingredient: {
         type: 'mm:item',
-        item: 'compressium:coal_2',
+        item: 'compressium:coal_3',
         count: 344064,
       },
     })
@@ -193,38 +193,11 @@ MMEvents.createProcesses((event) => {
       ingredient: {
         type: 'mm:item',
         item: 'bloodmagic:hellforgedparts',
-        count: 1,
-      },
-      chance: 0.133,
-    })
-    .output({
-      type: 'mm:output/simple',
-      ingredient: {
-        type: 'mm:item',
-        item: 'bloodmagic:hellforgedparts',
-        count: 1,
-      },
-      chance: 0.133,
-    })
-    .output({
-      type: 'mm:output/simple',
-      ingredient: {
-        type: 'mm:item',
-        item: 'bloodmagic:hellforgedparts',
-        count: 1,
-      },
-      chance: 0.133,
-    })
-    .output({
-      type: 'mm:output/simple',
-      ingredient: {
-        type: 'mm:item',
-        item: 'bloodmagic:hellforgedparts',
-        count: 1,
-      },
-      chance: 0.133,
+        count: 2,
+      }
     });
 
+    // This recipe is useless coal has emc using these ores is not worth it
       event
     .create('mm:silentgem_to_hellforged_parts')
     .structureId('mm:multi_compactor_structure')


### PR DESCRIPTION
Hellforged parts is barely needed, requiring the player to passive it is ridiculous

Requiring 2 billion power, 32 billion+ emc or otherwise this recipe isnt worth it anyway, and a 60 second wait; Just to not get anything is outrageous. Ontop of this multiblock requiring a philosophers stone which alone means you need infinity 8 to even get...

Making it the same amount but compressed 3x coal for guarenteed 2 parts is far superior. Even with your love for suffering this is FAR too much for you to be doing.

side note that silent gems ores recipe is actually useless nobody is ever going to use that because coal has emc and its a ridiculous amount of ores for needing to wait a full minute to only have a 20% chance to get 1 singular part